### PR TITLE
Detect file extension and include link tag when the file ends with *.css

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 grunt-script-include
 ===
 
-> Include script files individually for debugging:
+> Include script and css files individually for debugging:
 
 > An alternative to source maps, especially useful for browsers that don't support them.
 
@@ -35,12 +35,12 @@ Task targets, files and options may be specified according to the grunt [Configu
 #### include
 Type: `String`
 
-This option is a required option which specifies the full path to create your `<script>` tags in.
+This option is a required option which specifies the full path to create your `<script>`/`<link>` tags in.
 
 #### attributes
 Type: `String`
 
-This option specifies any space separated attributes to use on your `<script>` tags.  Defaults to ''.
+This option specifies any space separated attributes to use on your `<script>`/`<link>` tags.  Defaults to ''.
 
 ### Usage Examples
 

--- a/tasks/include.js
+++ b/tasks/include.js
@@ -35,7 +35,8 @@ module.exports = function (grunt) {
                 if (!grunt.file.exists(path)) {
                     grunt.log.warn('Source file "' + path + '" not found.');
                 } else {
-                    output.push(_.compact(['<script', options.attributes, 'src="' + relativePath + '"></script>']).join(' '));
+                    var ext = getExtension(relativePath);
+                    output.push(getTag(ext, options.attributes, relativePath).join(' '));
 
                     // Copy if it's not where it's suppose to be, overwriting existing files.
                     if (!grunt.file.arePathsEquivalent(path, file.dest)) {
@@ -54,4 +55,19 @@ module.exports = function (grunt) {
         }
 
     });
+    
+    function getTag(extension, attributes, path){
+        switch(extension){
+            case 'css':
+                return _.compact(['<link', attributes, 'rel="stylesheet" href="' + path + '"/>']);
+            case 'js':
+            default:
+                return _.compact(['<script', attributes, 'src="' + path + '"></script>']);
+        }
+    }
+
+    function getExtension(filename){
+        var i = filename.lastIndexOf('.');
+        return (i < 0) ? '' : filename.substr(i + 1);
+    }
 }


### PR DESCRIPTION
Hi, 
It now generates 'link' tags when include files are .css, for our integrators to debug styles.
thanks for the plugin :)
